### PR TITLE
Count extended fingers & build path modification

### DIFF
--- a/build/xcode/leapmotion.xcconfig
+++ b/build/xcode/leapmotion.xcconfig
@@ -26,7 +26,7 @@ HEADER_SEARCH_PATHS = $(MAX_HEADERS_DIR) $(MSP_HEADERS_DIR) $(JIT_HEADERS_DIR)
 FRAMEWORK_SEARCH_PATHS = "$(MAX_FRAMEWORK_DIR)/max-includes" "$(MAX_FRAMEWORK_DIR)/msp-includes" "$(MAX_FRAMEWORK_DIR)/jit-includes"
 
 // Install Directory
-DSTROOT = $(PROJECT_DIR)/../../../build-max5
+DSTROOT = $(PROJECT_DIR)/../../
 INSTALL_PATH = /
 
 // ----------------------------------

--- a/src/leapmotion.cpp
+++ b/src/leapmotion.cpp
@@ -138,7 +138,7 @@ void leapmotion_bang(t_leapmotion *x)
         const int32_t hand_id = hand.id();
 		
 		const Leap::FingerList &fingers = hand.fingers();
-		const size_t numFingers = fingers.count();
+		const size_t numFingers = fingers.extended().count();
 		
 		t_atom hand_data[11];
 		atom_setlong(hand_data, hand_id);


### PR DESCRIPTION
Hi,

I've been using your patch for a school project and have found it incredibly valuable, thank you so much for making it! If you're interested here are two commits that I think would make using the patch a slightly nicer experience. The two are completely unconnected and can be cherry picked if you would like one but not the other (assuming you want either at all). A little more detail on each commit:

1. `Count extended fingers only` - currently the `numfingers` value output by the patch is always as many fingers as one has on their hand (for me always five, don't have any friends with less fingers to test with 😄 ). I needed to count the number of extended fingers in the course of my project so I added `extended()` to the patch to do so (apologies if you're aware of this and purposely wanted total number of fingers vs extended).
2. `Generate target in repo root` - changes the target path to generate the patch at the root of the repo. This one is definitely opinionated, I found it slightly confusing that the build process generated a target outside the repo and in a max5 folder. I think generating it to the root might be a little more clear to users what they've generated.

Thanks again for making such a helpful tool! Please let me know if there's anything you'd like from me to help this pull request go through!